### PR TITLE
Only pick up workspace dirs

### DIFF
--- a/get-yarn-workspaces/index.js
+++ b/get-yarn-workspaces/index.js
@@ -24,5 +24,10 @@ module.exports = function getWorkspaces(from) {
   });
 
   const packages = getPackages(require(path.join(root, 'package.json')));
-  return flatten(packages.map(name => glob.sync(path.join(root, name))));
+  return flatten(
+    packages.map(name =>
+      // The trailing / ensures only dirs are picked up
+      glob.sync(path.join(root, `${name}/`))
+    )
+  );
 };


### PR DESCRIPTION
I have a README in a workspaces dir (eg. `packages/README.md`). Previously, the markdown file would be picked up as a workspace and I would get this error

> Root has to be a valid directory

This PR ensures only dirs are picked up. From the [node-glob docs](https://github.com/isaacs/node-glob)

> to match only directories, simply put a / at the end of the pattern.