### PR TITLE
Add option for disabling Metro .babelrc lookup

### DIFF
--- a/metro-bundler-config-yarn-workspaces/index.js
+++ b/metro-bundler-config-yarn-workspaces/index.js
@@ -29,6 +29,10 @@ module.exports = function getConfig(from, options = {}) {
         options.nodeModules || path.resolve(from, '..', 'node_modules'),
       ].concat(workspaces)
     },
+    getEnableBabelRCLookup() {
+      // Whether Metro should pick up .babelrc configs from host project
+      return options.enableBabelRCLookup || true
+    }
   }
   return config
 }

--- a/metro-bundler-config-yarn-workspaces/index.js
+++ b/metro-bundler-config-yarn-workspaces/index.js
@@ -31,8 +31,10 @@ module.exports = function getConfig(from, options = {}) {
     },
     getEnableBabelRCLookup() {
       // Whether Metro should pick up .babelrc configs from host project
-      return options.enableBabelRCLookup || true
-    }
+      return typeof options.enableBabelRCLookup === 'boolean'
+        ? options.enableBabelRCLookup
+        : true
+    },
   }
   return config
 }


### PR DESCRIPTION
In my case I have a root monorepo `.babelrc` that isn't compatible with the CRNA workspace, so returning `false` inside `rnConfig.getEnableBabelRCLookup` was a necessity. 

It would be nice for this to be merged to avoid using a fork.

I'm also OK with defaulting to `false`, but I think it was defaulting to `true` before (hence my issue), and continuing to do so would allow you to avoid a breaking change.