### PR TITLE
Check symlink source existence

### DIFF
--- a/crna-make-symlinks-for-yarn-workspaces/index.js
+++ b/crna-make-symlinks-for-yarn-workspaces/index.js
@@ -6,6 +6,10 @@ const link = (name, fromBase, toBase) => {
   const from = path.join(fromBase, 'node_modules', name);
   const to = path.join(toBase, 'node_modules', name);
 
+  if (!fs.existsSync(from)) {
+    return;
+  }
+
   if (fs.existsSync(to)) {
     fs.removeSync(to);
   }


### PR DESCRIPTION
In an ejected project without Expo reference expo symlink points to nonexistent space.
The existence condition returns false and causes fail because symlink already exists.